### PR TITLE
Build using `bundle` directly

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,18 +1,25 @@
-## Copied from https://github.com/actions/jekyll-build-pages
+## Copied from https://github.com/actions/starter-workflows/blob/c31fe3d5d44d7cb4c912f4c3213f7b4610f13ea2/pages/jekyll.yml
 name: Publish site
 
 on:
-  # Triggers the workflow on push or pull request events but only for the master branch
+  # Triggers the workflow on push or pull request events but only for the main branch
   push:
-    branches: ["master"]
+    branches: [$default-branch]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build:
@@ -21,11 +28,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@8575951200e472d5f2d95c625da0c7bec8217c42 # v1.161.0
+        with:
+          ruby-version: "3.1" # Not needed with a .ruby-version file
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          cache-version: 0 # Increment this number if you need to re-download cached gems
+
       - name: Setup Github Pages
         uses: actions/configure-pages@v3
 
-      - name: Build Jekyll site
-        uses: actions/jekyll-build-pages@v1
+      - name: Build with Jekyll
+        # Outputs to the './_site' directory by default
+        run: bundle exec jekyll build
+        env:
+          JEKYLL_ENV: production
 
       - name: Upload Github Pages artifact
         uses: actions/upload-pages-artifact@v1


### PR DESCRIPTION
Build using `bundle` directly

According to https://github.com/actions/jekyll-build-pages/blob/f8c0ea1228f54020a11722c1f10cb7d55cb3f710/entrypoint.sh#L16 we need to manually invoke `jekyll` instead of using their action.
